### PR TITLE
Don't set the X-Frame-Options header

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -10,6 +10,7 @@ require 'active_support/core_ext/object'
 use Rack::Cache
 set :public_folder, 'public'
 set :bind, '0.0.0.0'
+set :protection, :except => :frame_options
 
 if ENV['USERNAME'] && ENV['PASSWORD']
   use Rack::Auth::Basic, 'Demo area' do |user, pass|


### PR DESCRIPTION
Sinatra sets the X-Frame-Options header to `SAMEORIGIN` by default. This means we can't display this dashboard inside a frame.

I can't think of a reason why we might want to keep this enabled for this app, as it's a dashboard.

This explicitly disables the X-Frame-Options header as part of the initial Sinatra configuration.