### PR TITLE
Check password rather than setting it

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -14,7 +14,7 @@ set :protection, :except => :frame_options
 
 if ENV['USERNAME'] && ENV['PASSWORD']
   use Rack::Auth::Basic, 'Demo area' do |user, pass|
-    user == ENV['USERNAME'] && pass = ENV['PASSWORD']
+    user == ENV['USERNAME'] && pass == ENV['PASSWORD']
   end
 end
 


### PR DESCRIPTION
If a username and password is set in the environment and someone guesses the username then they can use any password to log in.

Oops.